### PR TITLE
fix: suppress JSDOM navigation warnings in tests

### DIFF
--- a/tests/plugin-system/ModuleLoader.test.js
+++ b/tests/plugin-system/ModuleLoader.test.js
@@ -21,16 +21,6 @@ describe('ModuleLoader', () => {
 
     // Reset fetch mock
     fetch.mockClear();
-
-    // Store original location and mock it
-    originalLocation = window.location;
-    delete window.location;
-    window.location = { href: 'https://test.com' };
-  });
-
-  afterEach(() => {
-    // Restore original location
-    window.location = originalLocation;
   });
 
   describe('Constructor', () => {


### PR DESCRIPTION
- Updated test setup to suppress "Not implemented: navigation" warnings
- Removed unnecessary location mocking in ModuleLoader tests
- Added console.error filtering and process.stderr interception
- All tests now pass without noise from JSDOM navigation warnings

Fixes #28

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description
Brief description of the changes in this PR.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Testing
- [x] Unit tests pass (`npm test`)
- [ ] Playwright tests pass (`npm run test:examples`)
- [ ] Build succeeds (`npm run build`)
- [ ] Linting passes (`npm run lint`)

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information or context about the PR.